### PR TITLE
fix: clarify and refine branching practices further

### DIFF
--- a/source-control/branching.md
+++ b/source-control/branching.md
@@ -37,6 +37,10 @@ For `develop`:
 - Pushing to branch should be restricted to certain teams/users, and bots
 - Prevent force pushes
 
+For `staging` and `uat`:
+
+- Pushing to branch should be restricted to certain teams/users
+
 For `release`:
 
 - Require reviews and status checks to pass before merging

--- a/source-control/branching.md
+++ b/source-control/branching.md
@@ -7,52 +7,82 @@ aim to make consistent across our repositories.
 
 ## Branch naming
 
-- Branch names should be kebab-case (lowercase only, - word separator)
+The default branches should have the following names:
 
-- Default and release branches should have the following names:
-  - `develop` - mainline branch, used to hold all developer changes
-  - `release` - used for releases into production
+- `develop` - mainline branch, used to hold all developer changes
+- `staging` - used for deploying into staging for pre-release testing
+- `uat` (optional) - used for deploying into UAT environments for user testing
+- `release` - used for releases into production
+- `master` - branch for stable releases
 
-- Branches for work-in-progress should follow an approach similar to
-  [conventional commits](https://www.conventionalcommits.org/).
-  - the format should be `<type>[/<scope>]/branch-name`
-  - examples are `feat/more-cowbell` and `fix/auth/schema-change`
+Branches names should be kebab-case and follow an approach similar to
+  [conventional commits](https://www.conventionalcommits.org/):
 
-- Branches for releases should take the format `release-<version>`
+- the format should be `<type>[/<scope>]/branch-name`
+- examples are `feat/more-cowbell`, `fix/auth/schema-change`
+
+Branches for releases should take the format `release-<version>`
 
 - Separate branches should be created for non-production environments.
   Ad-hoc releases can then be made from any arbitrary branch or commit
   via git force push, ie `git push -f origin <source-branch>:staging`
-  - `staging` should be created since most teams maintain a staging
-    environment for pre-release testing
 
 ## GitHub branch protection rules
 
-- Branch protection rules should be in place for `develop` and `release`
-  - Require reviews and status checks to pass before merging
-  - Pushing to branch can be restricted to certain teams, users 
-    and bots, if desired
-  - Prevent force pushes to `release`
+Branch protection rules should be in place.
+
+For `develop`:
+
+- Require reviews and status checks to pass before merging
+- Pushing to branch should be restricted to certain teams/users, and bots
+- Prevent force pushes
+
+For `release`:
+
+- Require reviews and status checks to pass before merging
+- Pushing to branch should be restricted to certain teams/users only
+- Prevent force pushes
+- Dismiss stale pull request approvals when new commits are pushed
 
 ## Branching strategy
 
-- Changes in mainline branch should be released as follows:
-  - create a branch from `staging` named `release-<version>`
-  - run `npm version <patch|minor>` on the newly-created branch
-  - run `git push -f origin release-<version>:staging`
-  - raise a PR merging `release-<version>` into `release` 
+### Releases
 
-- Feature branches should hang off and merge into the mainline branch
-  - Favour rebasing over merging to update feature branches
-  - Keep feature branches **small**. This makes the PR easier to understand,
-    and also makes it easier to rebase the feature branch on mainline should
-    the need arise
-  - If implementing a feature will take too many commits or too much change, 
-    you might be undertaking too much work in one go. If so, split the work
-    into more manageable chunks
+Changes in mainline branch should be released as follows:
 
-- Hotfixes and trivial changes can be squashed as a single commit onto mainline
+- check out a new release branch from `develop` named `release-<version>`
+- bump the ([semantic](https://semver.org/)) version by running `npm version <major|minor|patch>`
+  on the newly-created branch
+- push out the change to staging for [smoke testing](https://en.wikipedia.org/wiki/Smoke_testing_(software))
+  with `git push -f origin release-<version>:staging`
+- raise a PR _merging_ `release-<version>` into `release`
+- raise a PR _merging_ `release-<version>` into `develop`
+- if a bug is discovered during smoke testing, a fix can be raised against this release branch
+  and picked up subsequently in both `develop` and `release`
+
+### Hotfixes
+
+Hotfixes should be merged as follows:
+
+- check out a new patch branch from the previous release branch, also named `release-<version>`
+- write and verify a hotfix in development
+- bump the patch version by running `npm version patch` on the newly-created branch
+- push out the change to staging for smoke testing with `git push -f origin release-<version>:staging`
+- raise a PR _merging_ `release-<version>` into `release`
+- raise a PR _merging_ `release-<version>` into `develop`
+
+## Tips
+
+Feature branches should hang off and merge into the mainline branch.
+
+- Favour rebasing over merging to update feature branches
+- Keep feature branches **small**. This makes the PR easier to understand,
+  and also makes it easier to rebase the feature branch on mainline should
+  the need arise.
+- If implementing a feature will take too many commits or too much change,
+  you might be undertaking too much work in one go. If so, split the work
+  into more manageable chunks.
 
 ## Further reading
 
-See Atlassian's article on [Gitflow Workflow](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow), on which our strategy is loosely based on
+See Atlassian's article on [Gitflow Workflow](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow), on which our strategy is loosely based on.


### PR DESCRIPTION
Made the following refinements:
- Explicit inclusion of staging, uat and master branches
- Distinguish branch protection rules between release, uat/staging and other branches
- Distinguish the branching process between releases and hotfixes
- Linting

